### PR TITLE
Etag-based versioning for HTTP resource

### DIFF
--- a/assets/resource.py
+++ b/assets/resource.py
@@ -65,6 +65,11 @@ class HTTPResource:
         response = requests.request('GET', index, verify=verify)
         response.raise_for_status()
 
+        # Currently supports two types of http versioning.
+        # Etag-based versioning requires the site to have an 'etag'
+        #  (https://en.wikipedia.org/wiki/HTTP_ETag) defined.
+        # Regex-based versioning expects an index document that lists
+        #  the available versions in a regex-able fashion
         if source.get('etag'):
             return self.check_etag(source, version, response)
         else:

--- a/assets/resource.py
+++ b/assets/resource.py
@@ -15,6 +15,7 @@ class HTTPResource:
     """HTTP resource implementation."""
 
     def check_etag(self, source, version, response):
+        """Check for new version(s) based on an etag header."""
         etag = response.headers.get('etag')
 
         # With etags, there is no sense of continuity. Either the tag
@@ -25,6 +26,7 @@ class HTTPResource:
         return new_version
 
     def check_regex(self, source, version, response):
+        """Check for new version(s) based on a version regex."""
 
         regex = re.compile(source['regex'])
 

--- a/assets/resource.py
+++ b/assets/resource.py
@@ -18,6 +18,9 @@ class HTTPResource:
         """Check for new version(s) based on an etag header."""
         etag = response.headers.get('etag')
 
+        if etag is None:
+            raise Exception('Resource missing ETag')
+
         # With etags, there is no sense of continuity. Either the tag
         # matches or it is a new version.
         new_version = [{'version': etag}]
@@ -89,6 +92,7 @@ class HTTPResource:
             file_name = file_name.format(**version)
         else:
             file_name = uri.split('/')[-1]
+
         file_path = os.path.join(target_dir, file_name)
         version_file_path = os.path.join(target_dir, 'version')
 

--- a/test/test_check.py
+++ b/test/test_check.py
@@ -42,7 +42,7 @@ def test_check_etag(httpbin):
 
     output = cmd('check', source)
 
-    assert output == [{'version':'abc123'}]
+    assert output == [{'version': 'abc123'}]
 
 def test_check_etag_with_matching_version(httpbin):
     """Test if check returns latest version number."""
@@ -74,4 +74,4 @@ def test_check_etag_with_different_version(httpbin):
 
     output = cmd('check', source, version=version)
 
-    assert output == [{'version':'abc123'}]
+    assert output == [{'version': 'abc123'}]

--- a/test/test_check.py
+++ b/test/test_check.py
@@ -31,3 +31,47 @@ def test_check_with_version(httpbin):
         {'version': '8'},
         {'version': '9'},
     ]
+
+def test_check_etag(httpbin):
+    """Test if check returns latest version number."""
+
+    source = {
+      'index': httpbin + '/response-headers?Etag=abc123',
+      'etag': 'true'
+    }
+
+    output = cmd('check', source)
+
+    assert output == [{'version':'abc123'}]
+
+def test_check_etag_with_matching_version(httpbin):
+    """Test if check returns latest version number."""
+
+    source = {
+      'index': httpbin + '/response-headers?Etag=abc123',
+      'etag': 'true'
+    }
+
+    version = {
+        'version': 'abc123'
+    }
+
+    output = cmd('check', source, version=version)
+
+    assert output == []
+
+def test_check_etag_with_different_version(httpbin):
+    """Test if check returns latest version number."""
+
+    source = {
+      'index': httpbin + '/response-headers?Etag=abc123',
+      'etag': 'true'
+    }
+
+    version = {
+        'version': 'xyz789'
+    }
+
+    output = cmd('check', source, version=version)
+
+    assert output == [{'version':'abc123'}]

--- a/test/test_check.py
+++ b/test/test_check.py
@@ -1,3 +1,5 @@
+import pytest
+
 from helpers import cmd
 
 
@@ -31,6 +33,22 @@ def test_check_with_version(httpbin):
         {'version': '8'},
         {'version': '9'},
     ]
+
+def test_check_with_latest_version(httpbin):
+    """Test if check returns no version numbers."""
+
+    source = {
+        'index': httpbin + '/links/10',
+        'regex': "href='/links/10/(?P<version>[0-9]+)'",
+    }
+
+    version = {
+        'version': '9',
+    }
+
+    output = cmd('check', source, version=version)
+
+    assert output == []
 
 def test_check_etag(httpbin):
     """Test if check returns latest version number."""
@@ -75,3 +93,18 @@ def test_check_etag_with_different_version(httpbin):
     output = cmd('check', source, version=version)
 
     assert output == [{'version': 'abc123'}]
+
+def test_check_etag_with_no_etag_on_site(httpbin):
+    """It should throw an error if the etag is missing."""
+
+    source = {
+      'index': httpbin + '/get',
+      'etag': 'true'
+    }
+
+    version = {
+        'version': 'xyz789'
+    }
+
+    with pytest.raises(Exception):
+        cmd('check', source, version=version)

--- a/test/test_in.py
+++ b/test/test_in.py
@@ -35,3 +35,21 @@ def test_in_filename(httpbin, tmpdir):
 
     assert in_dir.join('filename_9').exists()
     assert len(in_dir.join('filename_9').read()) == 9
+
+def test_in_unversioned_filename(httpbin, tmpdir):
+    """Test downloading unversioned file with predetermined filename."""
+
+    source = {
+        'uri': httpbin + '/range/9',
+        'filename': 'filename',
+    }
+
+    in_dir = tmpdir.mkdir('work_dir')
+
+    output = cmd('in', source, [str(in_dir)], {'version': '9'})
+
+    assert output == {'version': {'version': '9'}, 'metadata': []}
+
+    assert in_dir.join('filename').exists()
+    assert len(in_dir.join('filename').read()) == 9
+

--- a/test/test_in.py
+++ b/test/test_in.py
@@ -52,4 +52,3 @@ def test_in_unversioned_filename(httpbin, tmpdir):
 
     assert in_dir.join('filename').exists()
     assert len(in_dir.join('filename').read()) == 9
-


### PR DESCRIPTION
This is mostly working, but I want to get some more tests in here to cover edge cases. After that, I'll submit a PR upstream.

Feedback on the approach would be appreciated.

@afeld, @ctro
